### PR TITLE
flakes: Use NixOS/nixpkgs with gtk-declarative fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1592754205,
-        "narHash": "sha256-CQzP4Ur/lNGKQQCQlA5E44rmJmZcAparDDHAus5evH4=",
-        "owner": "balsoft",
+        "lastModified": 1592810120,
+        "narHash": "sha256-1xlD1OIs75DvjkWpyZcQBjdu/IgugspPpz8CsBeutaM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50dd17125c2923e30ff06aeafdfee29b9be9ade",
+        "rev": "dbcd55844106241cf2d6aa0bc6ccb1613d1a5ed4",
         "type": "github"
       },
       "original": {
-        "owner": "balsoft",
-        "ref": "fix-gi-gtk-declarative",
+        "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "dbcd55844106241cf2d6aa0bc6ccb1613d1a5ed4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A launcher written in Haskell";
 
-  inputs.nixpkgs.url = github:balsoft/nixpkgs/fix-gi-gtk-declarative;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/dbcd55844106241cf2d6aa0bc6ccb1613d1a5ed4;
 
   outputs = { self, nixpkgs }: {
     packages = builtins.mapAttrs (_: pkgs: rec {


### PR DESCRIPTION
Hello, in flakes.nix nixpkgs.url was referring to no longer existing branch, which had been merged into nixpkgs and deleted, so I changed url to the corresponding merge commit.