### PR TITLE
Use streamly for concurrency

### DIFF
--- a/lambda-launcher.cabal
+++ b/lambda-launcher.cabal
@@ -25,6 +25,7 @@ executable lambda-launcher
                       , req
                       , data-default-class == 0.*
                       , fuzzy == 0.1.*
+                      , streamly
   hs-source-dirs:       src
   other-modules:        LambdaLauncher.Types
                       , LambdaLauncher.Main
@@ -35,6 +36,7 @@ executable lambda-launcher
                       , LambdaLauncher.Plugins.Files
                       , LambdaLauncher.Plugins.Google
                       , LambdaLauncher.Plugins.Command
+                      , LambdaLauncher.Plugins.Dictionary
                       , LambdaLauncher.Plugins.Emacs
                       , LambdaLauncher.Plugins.Wiki
                       , LambdaLauncher.Plugins.Stackoverflow

--- a/lambda-launcher.nix
+++ b/lambda-launcher.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, async, base, bytestring, data-default-class
 , directory, filepath, fuzzy, gi-gdk, gi-glib, gi-gobject, gi-gtk
 , gi-gtk-declarative, gi-gtk-declarative-app-simple, haskell-gi
-, haskell-gi-base, process, req, stdenv, text, vector
+, haskell-gi-base, process, req, stdenv, streamly, text, vector
 }:
 mkDerivation {
   pname = "lambda-launcher";
@@ -13,7 +13,7 @@ mkDerivation {
     aeson async base bytestring data-default-class directory filepath
     fuzzy gi-gdk gi-glib gi-gobject gi-gtk gi-gtk-declarative
     gi-gtk-declarative-app-simple haskell-gi haskell-gi-base process
-    req text vector
+    req streamly text vector
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/src/LambdaLauncher/Main.hs
+++ b/src/LambdaLauncher/Main.hs
@@ -36,7 +36,7 @@ import GI.Gtk.Declarative.App.Simple
 
 import Data.Functor (($>))
 import Data.Text (Text, lines)
-import Data.List (genericLength, sortOn)
+import Data.List (nub, genericLength, sortOn)
 
 import Streamly
 import qualified Streamly.Prelude as S
@@ -60,13 +60,6 @@ data State = State
 
 instance Eq Result where
   a == b = shownText a == shownText b
-
-removeSame :: Eq a => [a] -> [a] -> [a]
-removeSame found (x:xs) =
-  if x `elem` found
-  then removeSame found xs
-  else removeSame (x:found) xs
-removeSame found _ = found
 
 cutOffAt :: Text -> Int -> Text
 s `cutOffAt` i =
@@ -143,7 +136,7 @@ update' Configuration {..} _ state (ResultAdded q x chan) =
   where
     queryMatch = q == query state
     anyTriggered = any  ((== 0) . priority) newResults
-    newResults = removeSame [] x
+    newResults = nub x
 
 update' _ _ state (Activated a) = Transition state $ a $> Just Closed
 update' _ _ _ Closed = Exit

--- a/src/LambdaLauncher/Main.hs
+++ b/src/LambdaLauncher/Main.hs
@@ -30,16 +30,16 @@ import GI.Gtk
   , getEntryText
   )
 
-import qualified GI.Gtk as Gtk
+-- import qualified GI.Gtk as Gtk
 import GI.Gtk.Declarative
 import GI.Gtk.Declarative.App.Simple
-
-import Control.Concurrent
-import Control.Concurrent.Chan
 
 import Data.Functor (($>))
 import Data.Text (Text, lines)
 import Data.List (genericLength, sortOn)
+
+import Streamly
+import qualified Streamly.Prelude as S
 
 import LambdaLauncher.Types
 
@@ -49,7 +49,7 @@ data Event
   = QueryChanged Text
   | ResultAdded Text
                 [Result]
-                (Chan [Result])
+                (SerialT IO [Result])
   | Activated (IO ())
   | Closed
 
@@ -115,20 +115,18 @@ searchView Configuration {..} State {results} =
     toQueryChangedEvent :: SearchEntry -> IO Event
     toQueryChangedEvent w = QueryChanged <$> getEntryText w
 
-runPlugin :: Chan [Result] -> Text -> Plugin -> IO ()
-runPlugin chan q plugin = void $ forkIO $ plugin q >>= writeChan chan
+runPlugin :: Text -> Plugin -> IO (Maybe [Result])
+runPlugin q plugin = optional $ plugin q
 
-updateResults :: Text -> Chan [Result] -> IO (Maybe Event)
-updateResults q chan = fmap (\x -> ResultAdded q x chan) <$> (optional $ readChan chan)
+updateResults :: Text -> SerialT IO [Result] -> IO (Maybe Event)
+updateResults q s = fmap (uncurry $ ResultAdded q) <$> S.uncons s
 
 update' :: Configuration -> [Plugin] -> State -> Event -> Transition State Event
 update' _ _ state (QueryChanged "") =
   Transition state {query = "", results = []} $ return Nothing
 update' _ plugins state (QueryChanged s) =
   Transition state {query = s, results = []} $ do
-    chan <- newChan
-    mapM_ (runPlugin chan s) plugins
-    updateResults s chan
+    updateResults s $ parallely $ S.mapMaybeM (runPlugin s) $ S.fromList plugins
 update' Configuration {..} _ state (ResultAdded q x chan) =
   Transition
     state
@@ -146,7 +144,7 @@ update' Configuration {..} _ state (ResultAdded q x chan) =
     queryMatch = q == query state
     anyTriggered = any  ((== 0) . priority) newResults
     newResults = removeSame [] x
-    
+
 update' _ _ state (Activated a) = Transition state $ a $> Just Closed
 update' _ _ _ Closed = Exit
 


### PR DESCRIPTION
As I mentioned in #7, streamly is a nice streaming library with good support for concurrency. I tried replacing the old `forkIO` + `Chan` method with streamly to learn about the library, and I'd say the change was very simple and the result is elegant.

Further possibilites would be to replace the list with a stream inside the plugins as well, but that is probably overkill.