### PR TITLE
Automatically update flake.lock to the latest version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1626297695,
-        "narHash": "sha256-IHdVgRcpn57ldEKZ9FeLhFrElSH+jse8mtcbyMwatPU=",
+        "lastModified": 1626298850,
+        "narHash": "sha256-VOGvZufOboHzw1yMrK5j0ndvFLYi/p2kgMB8tzjdUSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8230082bc3ffb6e5cb80ed5b41f297e7c5c3ca90",
+        "rev": "8395a2d284c9df06f1c40e4ed0b5ca709ff22c37",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1626298850,
-        "narHash": "sha256-VOGvZufOboHzw1yMrK5j0ndvFLYi/p2kgMB8tzjdUSo=",
+        "lastModified": 1626300184,
+        "narHash": "sha256-1B5P7EUAFeA+P7m6jzbHtrMKcIkPCjQj7lfQPmrYL44=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8395a2d284c9df06f1c40e4ed0b5ca709ff22c37",
+        "rev": "23cd13167a1432550e48734079c2ffeeb441fb96",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1626300184,
-        "narHash": "sha256-1B5P7EUAFeA+P7m6jzbHtrMKcIkPCjQj7lfQPmrYL44=",
+        "lastModified": 1626335534,
+        "narHash": "sha256-xhHB/qDGVDS76/isfzYWDGcqjcsAY7ZEzpzxer6zAAc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23cd13167a1432550e48734079c2ffeeb441fb96",
+        "rev": "204f7dc3350f0b5c97b236c3fff0f65002c857f6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1614531970,
-        "narHash": "sha256-cfsbJwD5t8b03YQW7/F4hlYO19ACV/BIDIiRJ4V43V4=",
+        "lastModified": 1624291530,
+        "narHash": "sha256-yZ3HfgbLW5yGCriCsFPt9TE1wsMLj3lFozzvlPxW4dA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ddf21160e30fbd75c344a8939cc6d518f88409a1",
+        "rev": "3be5e9248e23f5dbf0863c9fc6a0f2cbe1ef3484",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1624291530,
-        "narHash": "sha256-yZ3HfgbLW5yGCriCsFPt9TE1wsMLj3lFozzvlPxW4dA=",
+        "lastModified": 1626297695,
+        "narHash": "sha256-IHdVgRcpn57ldEKZ9FeLhFrElSH+jse8mtcbyMwatPU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3be5e9248e23f5dbf0863c9fc6a0f2cbe1ef3484",
+        "rev": "8230082bc3ffb6e5cb80ed5b41f297e7c5c3ca90",
         "type": "github"
       },
       "original": {

--- a/wrapper.nix
+++ b/wrapper.nix
@@ -3,8 +3,7 @@
 lambda-launcher-unwrapped.overrideAttrs (old: {
   buildInputs = old.buildInputs ++ [ makeWrapper ];
   postInstall = ''
-    cp $out/bin/lambda-launcher $out/bin/.lambda-launcher-unwrapped
-    makeWrapper $out/bin/.lambda-launcher-unwrapped $out/bin/lambda-launcher --prefix PATH : ${
+    wrapProgram $out/bin/lambda-launcher --prefix PATH : ${
       lib.makeBinPath plugins
     } --prefix LD_LIBRARY_PATH : ${librsvg}/lib
   '';


### PR DESCRIPTION
| input | old | new | diff |
|-------|-----|-----|------|
| nixpkgs | `ddf21160e3 (2021-02-28)` | `204f7dc335 (2021-07-15)` | [link](https://github.com/NixOS/nixpkgs/compare/ddf21160e30fbd75c344a8939cc6d518f88409a1...204f7dc3350f0b5c97b236c3fff0f65002c857f6?expand=1) |

